### PR TITLE
Add Coloured Console.

### DIFF
--- a/Part3/level48/ColouredConsoleChallenge/ColouredConsoleApp/ColouredConsoleApp.csproj
+++ b/Part3/level48/ColouredConsoleChallenge/ColouredConsoleApp/ColouredConsoleApp.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ColouredConsoleLibrary\ColouredConsoleLibrary.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Part3/level48/ColouredConsoleChallenge/ColouredConsoleApp/Program.cs
+++ b/Part3/level48/ColouredConsoleChallenge/ColouredConsoleApp/Program.cs
@@ -1,0 +1,6 @@
+﻿#region Using Directives
+using ColouredConsoleLibrary;
+#endregion
+
+var name = ColouredConsole.Prompt("What is your name");
+ColouredConsole.WriteLine($"Hello {name}", ConsoleColor.Green);

--- a/Part3/level48/ColouredConsoleChallenge/ColouredConsoleApp/README.md
+++ b/Part3/level48/ColouredConsoleChallenge/ColouredConsoleApp/README.md
@@ -1,0 +1,18 @@
+# Coloured Console
+
+The Medallion of Large Solutions lies behind a sealed stone door and can only be unlocked by building a solution with tqo correctly linked projects. This multi-project solution is a key that unseals the door.
+
+## Objectives
+
+- Create a new console project from scratch.
+- Add a second Class Library project to the solution.
+- Add a static class, `ColouredConsole`, to the library project.
+- Add the method `public static string Prompt(string question)` that writes `question` to the console, then switched to `cyan` to get the user's response all on the same line.
+- Add the method `public static void WriteLine(string text, ConsoleColor color)` that write the given text on its own line in the given colour.
+- Add the method `public static void Write(string text, ConsoleColor color)` that writes the given text without a new line in the given colour.
+- Add the right references between projects so that the main program can use the following code:
+
+````c#
+string name = ColouredConsole.Prompt("What is your name");
+ColouredConsole.WriteLine($"Hello {name}", ConsoleColor.Green);
+````

--- a/Part3/level48/ColouredConsoleChallenge/ColouredConsoleLibrary/ColouredConsole.cs
+++ b/Part3/level48/ColouredConsoleChallenge/ColouredConsoleLibrary/ColouredConsole.cs
@@ -1,0 +1,27 @@
+﻿namespace ColouredConsoleLibrary
+{
+    /// <summary>
+    ///     Write to the console using coloured text.
+    /// </summary>
+    public static class ColouredConsole
+    {
+        public static string? Prompt(string question)
+        {
+            Console.Write($"{question}? ");
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            return Console.ReadLine();
+        }
+
+        public static void Write(string text, ConsoleColor color)
+        {
+            Console.ForegroundColor = color;
+            Console.Write(text);
+        }
+
+        public static void WriteLine(string text, ConsoleColor color)
+        {
+            Console.ForegroundColor = color;
+            Console.WriteLine(text);
+        }
+    }
+}

--- a/Part3/level48/ColouredConsoleChallenge/ColouredConsoleLibrary/ColouredConsoleLibrary.csproj
+++ b/Part3/level48/ColouredConsoleChallenge/ColouredConsoleLibrary/ColouredConsoleLibrary.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/PlayersGuide.sln
+++ b/PlayersGuide.sln
@@ -205,9 +205,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "manyRandomWords", "part3\le
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "level45", "level45", "{17634B5E-6B41-4A76-AC3F-8B35B85F793E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "uniterOfAdds", "part3\level45\uniterOfAdds\uniterOfAdds.csproj", "{77FF0E10-80C6-4302-A6BF-32BD1457976A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "uniterOfAdds", "part3\level45\uniterOfAdds\uniterOfAdds.csproj", "{77FF0E10-80C6-4302-A6BF-32BD1457976A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "robotFactory", "part3\level45\robotFactory\robotFactory.csproj", "{E86E59C2-085C-43ED-8399-7C727845343E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "robotFactory", "part3\level45\robotFactory\robotFactory.csproj", "{E86E59C2-085C-43ED-8399-7C727845343E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "level48", "level48", "{6D2FB712-FC11-478E-81BF-C328EEE738BB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ColouredConsoleApp", "Part3\level48\ColouredConsoleChallenge\ColouredConsoleApp\ColouredConsoleApp.csproj", "{00047BA2-895B-480A-ADC0-D71147B92882}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ColouredConsoleLibrary", "Part3\level48\ColouredConsoleChallenge\ColouredConsoleLibrary\ColouredConsoleLibrary.csproj", "{29DF680F-3145-46B8-B40F-56343FA8440C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -451,6 +457,14 @@ Global
 		{E86E59C2-085C-43ED-8399-7C727845343E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E86E59C2-085C-43ED-8399-7C727845343E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E86E59C2-085C-43ED-8399-7C727845343E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00047BA2-895B-480A-ADC0-D71147B92882}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00047BA2-895B-480A-ADC0-D71147B92882}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00047BA2-895B-480A-ADC0-D71147B92882}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00047BA2-895B-480A-ADC0-D71147B92882}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29DF680F-3145-46B8-B40F-56343FA8440C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29DF680F-3145-46B8-B40F-56343FA8440C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29DF680F-3145-46B8-B40F-56343FA8440C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29DF680F-3145-46B8-B40F-56343FA8440C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -556,6 +570,9 @@ Global
 		{17634B5E-6B41-4A76-AC3F-8B35B85F793E} = {E6060E96-147A-4BB1-8673-1ACA721842E7}
 		{77FF0E10-80C6-4302-A6BF-32BD1457976A} = {17634B5E-6B41-4A76-AC3F-8B35B85F793E}
 		{E86E59C2-085C-43ED-8399-7C727845343E} = {17634B5E-6B41-4A76-AC3F-8B35B85F793E}
+		{6D2FB712-FC11-478E-81BF-C328EEE738BB} = {E6060E96-147A-4BB1-8673-1ACA721842E7}
+		{00047BA2-895B-480A-ADC0-D71147B92882} = {6D2FB712-FC11-478E-81BF-C328EEE738BB}
+		{29DF680F-3145-46B8-B40F-56343FA8440C} = {6D2FB712-FC11-478E-81BF-C328EEE738BB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F9CE9BD2-E80F-4C81-B512-F1FA1D48E5FC}


### PR DESCRIPTION
Add a multi-project application and reference methods from the second project from the first project.

Two projects have been created: `ColouredConsoleApp` and `ColouredConsoleLibrary`. `ColouredConsoleLibrary` contains methods for reading from and writing to the console; `ColouredConsoleApp` references those methods to generate a very simple program that requests input from the user and displays output based on the value provided.

The two projects are linked using a Project reference, where the source code for both projects can be viewed or edited as needed.