### PR TITLE
Add offensive attack modifiers

### DIFF
--- a/Part4/level52/FinalBattle.Character/Attack.cs
+++ b/Part4/level52/FinalBattle.Character/Attack.cs
@@ -13,7 +13,8 @@ public abstract class Attack
 
     #region Constructors
     /// <inheritdoc />
-    protected Attack(string name, float chanceToHit, int damage) : this(name, DamageType.Normal, chanceToHit, damage) {}
+    protected Attack(string name, float chanceToHit, int damage, AttackModifier? attackModifier = null) :
+        this(name, DamageType.Normal, chanceToHit, damage, attackModifier) {}
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="Attack" /> class.
@@ -25,43 +26,45 @@ public abstract class Attack
     ///     an automatic hit.
     /// </param>
     /// <param name="damage">The amount of damage that the attack inflicts.</param>
-    protected Attack(string name, DamageType damageType, float chanceToHit, int damage)
+    /// <param name="attackModifier">The attack modifier applied to this attack.</param>
+    protected Attack(string name, DamageType damageType, float chanceToHit, int damage, AttackModifier? attackModifier = null)
     {
-        Name        = name.ToUpper();
-        ChanceToHit = chanceToHit;
-        DamageType  = damageType;
-        Damage      = damage;
+        Name           = name;
+        DamageType     = damageType;
+        ChanceToHit    = chanceToHit;
+        Damage         = damage;
+        AttackModifier = attackModifier;
     }
     #endregion
 
     #region Properties
     /// <summary>
+    ///     Gets or sets the attack modifier.
+    /// </summary>
+    public AttackModifier? AttackModifier {get;}
+
+    /// <summary>
     ///     Gets the chance to hit.
     /// </summary>
-    /// <value>
-    ///     The chance to hit.
-    /// </value>
     public float ChanceToHit {get;}
 
     /// <summary>
     ///     Gets the damage.
     /// </summary>
-    /// <value>
-    ///     The damage.
-    /// </value>
     public int Damage {get;}
 
+    /// <summary>
+    ///     Gets the damage type.
+    /// </summary>
     public DamageType DamageType {get;}
 
     /// <summary>
     ///     Gets the name.
     /// </summary>
-    /// <value>
-    ///     The name.
-    /// </value>
     protected string Name {get;}
     #endregion
 
+    #region Methods
     /// <summary>
     ///     Calculates the damage.
     /// </summary>
@@ -74,15 +77,8 @@ public abstract class Attack
     /// <returns>
     ///     <c>true</c> if this attack was successful; otherwise, <c>false</c>.
     /// </returns>
-    public bool IsSuccess() =>
-        ChanceToHit switch
-        {
-            0 => false,
-            1 => true,
-            _ => random.NextSingle() <= ChanceToHit
-        };
+    public bool IsSuccess() => random.NextDouble() < ChanceToHit;
 
-    #region Overrides of Object
     /// <inheritdoc />
     public override string ToString() => Name;
     #endregion

--- a/Part4/level52/FinalBattle.Character/AttackModifier.cs
+++ b/Part4/level52/FinalBattle.Character/AttackModifier.cs
@@ -76,9 +76,9 @@ public class AttackModifier
         }
 
         // Check if the attack is Gear-based and apply Gear-specific logic
-        if (attackData.Attack is Gear gear && gear.Modifier != null)
+        if (attackData.Attack is Gear {AttackModifier: not null} gear)
         {
-            Modifier = gear.Modifier.Modifier;
+            Modifier = gear.AttackModifier!.Modifier;
         }
 
         // Standard modifier logic

--- a/Part4/level52/FinalBattle.Character/AttackModifier.cs
+++ b/Part4/level52/FinalBattle.Character/AttackModifier.cs
@@ -41,12 +41,12 @@ public class AttackModifier
     /// </value>
     public bool HasModifier => Modifier != 0;
 
-    public AttackModifierType ModifierType {get;}
-
     /// <summary>
     ///     Gets the value of the attack modifier.
     /// </summary>
-    private int Modifier {get; set;}
+    public int Modifier {get; set;}
+
+    public AttackModifierType ModifierType {get;}
 
     /// <summary>
     ///     Gets the name of the attack modifier.

--- a/Part4/level52/FinalBattle.Character/AttackModifier.cs
+++ b/Part4/level52/FinalBattle.Character/AttackModifier.cs
@@ -4,6 +4,7 @@ namespace FinalBattle.Character;
 
 #region Using Directives
 using Attacks;
+using GearItems;
 #endregion
 
 /// <summary>
@@ -45,7 +46,7 @@ public class AttackModifier
     /// <summary>
     ///     Gets the value of the attack modifier.
     /// </summary>
-    private int Modifier {get;}
+    private int Modifier {get; set;}
 
     /// <summary>
     ///     Gets the name of the attack modifier.
@@ -62,18 +63,27 @@ public class AttackModifier
     #endregion
 
     /// <summary>
-    ///     Modifies the attack by Modifier.
+    ///     Modifies the attack by Modifier, including Gear-based modifiers.
     /// </summary>
     /// <param name="attackData">The original attack data.</param>
     /// <returns>A new <c>AttackData</c> object with a modified damage amount.</returns>
     public AttackData ModifyAttack(AttackData attackData)
     {
+        // Handle standard modifiers
         if (Modifier == 0 || (ModifierType == AttackModifierType.Defensive && attackData.Attack?.DamageType != ResistsDamageType))
         {
             return attackData;
         }
 
+        // Check if the attack is Gear-based and apply Gear-specific logic
+        if (attackData.Attack is Gear gear && gear.Modifier != null)
+        {
+            Modifier = gear.Modifier.Modifier;
+        }
+
+        // Standard modifier logic
         var message = ModifierType == AttackModifierType.Offensive ? $"{this} added {Modifier} damage" : $"{this} reduced damage by {Math.Abs(Modifier)}";
+
         return new AttackData(attackData.Attack ?? new NoAttack(), message, attackData.Damage + Modifier);
     }
 

--- a/Part4/level52/FinalBattle.Character/AttackModifier.cs
+++ b/Part4/level52/FinalBattle.Character/AttackModifier.cs
@@ -13,19 +13,21 @@ public class AttackModifier
 {
     #region Constructors
     /// <inheritdoc />
-    public AttackModifier(string name = "none", int modifier = 0) : this(name, DamageType.Normal, modifier) {}
+    public AttackModifier(string name = "none", int modifier = 0) : this(name, AttackModifierType.Defensive, DamageType.Normal, modifier) {}
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="AttackModifier" /> class.
     /// </summary>
     /// <param name="name">The name of the attack modifier.</param>
+    /// <param name="modifierType">The Attack Modifier type (offensive or defensive).</param>
     /// <param name="resistsDamageType">The type of damage that the attack modifier resists. The default is <c>Normal</c>.</param>
     /// <param name="modifier">The value of the attack modifier.</param>
-    public AttackModifier(string name, DamageType resistsDamageType, int modifier)
+    public AttackModifier(string name, AttackModifierType modifierType, DamageType resistsDamageType, int modifier)
     {
         Name              = name;
         Modifier          = modifier;
         ResistsDamageType = resistsDamageType;
+        ModifierType      = modifierType;
     }
     #endregion
 
@@ -37,6 +39,8 @@ public class AttackModifier
     ///     <c>true</c> if this instance has an Attack Modifier; otherwise, <c>false</c>.
     /// </value>
     public bool HasModifier => Modifier != 0;
+
+    public AttackModifierType ModifierType {get;}
 
     /// <summary>
     ///     Gets the value of the attack modifier.
@@ -62,12 +66,16 @@ public class AttackModifier
     /// </summary>
     /// <param name="attackData">The original attack data.</param>
     /// <returns>A new <c>AttackData</c> object with a modified damage amount.</returns>
-    public AttackData ModifyAttack(AttackData attackData) => attackData.Attack?.DamageType != ResistsDamageType
-                                                                 ? attackData
-                                                                 : new AttackData(
-                                                                     attackData.Attack ?? new NoAttack(),
-                                                                     $"{this} reduced damage by {Math.Abs(Modifier)}",
-                                                                     attackData.Damage + Modifier);
+    public AttackData ModifyAttack(AttackData attackData)
+    {
+        if (Modifier == 0 || (ModifierType == AttackModifierType.Defensive && attackData.Attack?.DamageType != ResistsDamageType))
+        {
+            return attackData;
+        }
+
+        var message = ModifierType == AttackModifierType.Offensive ? $"{this} added {Modifier} damage" : $"{this} reduced damage by {Math.Abs(Modifier)}";
+        return new AttackData(attackData.Attack ?? new NoAttack(), message, attackData.Damage + Modifier);
+    }
 
     #region Overrides of Object
     /// <inheritdoc />

--- a/Part4/level52/FinalBattle.Character/Attacks/ChargedPunch.cs
+++ b/Part4/level52/FinalBattle.Character/Attacks/ChargedPunch.cs
@@ -1,0 +1,19 @@
+﻿namespace FinalBattle.Character.Attacks
+{
+    /// <summary>
+    ///     A Punch attack
+    /// </summary>
+    /// <seealso cref="FinalBattle.Character.Attack" />
+    internal class ChargedPunch : Attack
+    {
+        #region Constructors
+        /// <inheritdoc />
+        public ChargedPunch() : base("charged punch", DamageType.Physical, .9f, 2, new AttackModifier("Charge", AttackModifierType.Offensive, DamageType.Physical, 1)) {}
+        #endregion
+
+        #region Implementation of IAttack
+        /// <inheritdoc />
+        public override int CalculateDamage() => Damage;
+        #endregion
+    }
+}

--- a/Part4/level52/FinalBattle.Character/Characters/TrueProgrammer.cs
+++ b/Part4/level52/FinalBattle.Character/Characters/TrueProgrammer.cs
@@ -15,6 +15,7 @@ public class TrueProgrammer : Character
 {
     #region Constructors
     /// <inheritdoc />
-    public TrueProgrammer(string name) : base(name, new[] {new Punch()}, new AttackModifier("Object Sight", DamageType.Decoding, -2), 25) => EquippedGear = new Sword();
+    public TrueProgrammer(string name) : base(name, new[] {new Punch()}, new AttackModifier("Object Sight", AttackModifierType.Defensive, DamageType.Decoding, -2), 25) =>
+        EquippedGear = new FlamingSword();
     #endregion
 }

--- a/Part4/level52/FinalBattle.Character/Characters/TrueProgrammer.cs
+++ b/Part4/level52/FinalBattle.Character/Characters/TrueProgrammer.cs
@@ -15,7 +15,11 @@ public class TrueProgrammer : Character
 {
     #region Constructors
     /// <inheritdoc />
-    public TrueProgrammer(string name) : base(name, new[] {new Punch()}, new AttackModifier("Object Sight", AttackModifierType.Defensive, DamageType.Decoding, -2), 25) =>
+    public TrueProgrammer(string name) : base(
+        name,
+        new Attack[] {new Punch(), new ChargedPunch()},
+        new AttackModifier("Object Sight", AttackModifierType.Defensive, DamageType.Decoding, -2),
+        25) =>
         EquippedGear = new FlamingSword();
     #endregion
 }

--- a/Part4/level52/FinalBattle.Character/ExtensionMethods.cs
+++ b/Part4/level52/FinalBattle.Character/ExtensionMethods.cs
@@ -27,7 +27,7 @@ public static class ExtensionMethods
         return action switch
         {
             Action.DoNothing => new AttackData($"{character} did NOTHING."),
-            Action.Attack    => AttackTarget(character, GetPreferredAttack(isComputerPlayer, character), targetCharacter!),
+            Action.Attack    => AttackTarget(character, GetPreferredAttack(isComputerPlayer, character), targetCharacter),
             _                => throw new ArgumentOutOfRangeException(nameof(action), action, null)
         };
     }
@@ -61,21 +61,22 @@ public static class ExtensionMethods
         // Allow human player to choose attack.
         var attacks = new List<Attack> {character.EquippedGear}; // Equipped gear is always the first attack option
         attacks.AddRange(character.Attacks);
-        var index = 0;
+        var index = 1;
         Console.WriteLine("You can choose from the following attacks:");
         foreach (var attack in attacks)
         {
-            Console.WriteLine($"{index}: {attack} ({attack.Damage} damage, {attack.ChanceToHit:P0} chance to hit)");
+            var modifier = attack.AttackModifier is null ? string.Empty : $" + {attack.AttackModifier.Modifier} {attack.AttackModifier} damage";
+            Console.WriteLine($"{index}: {attack} ({attack.Damage} damage{modifier}, {attack.ChanceToHit:P0} chance to hit)");
             index++;
         }
 
-        index = -1;
-        while (index < 0)
+        index = 0;
+        while (index < 1 || index > attacks.Count)
         {
             Console.Write("Which attack do you choose? ");
             int.TryParse(Console.ReadLine(), out index);
         }
 
-        return attacks[index];
+        return attacks[index - 1];
     }
 }

--- a/Part4/level52/FinalBattle.Character/GearItems/FlamingSword.cs
+++ b/Part4/level52/FinalBattle.Character/GearItems/FlamingSword.cs
@@ -9,7 +9,7 @@
     {
         #region Constructors
         /// <inheritdoc />
-        public FlamingSword() : base("slash", 0.75f, 2, new AttackModifier("fire", AttackModifierType.Offensive, DamageType.Fire, 2)) {}
+        public FlamingSword() : base("slash", 0.75f, 2, new AttackModifier("fire", AttackModifierType.Offensive, DamageType.Fire, 1)) {}
         #endregion
 
         #region Overrides of Attack

--- a/Part4/level52/FinalBattle.Character/GearItems/FlamingSword.cs
+++ b/Part4/level52/FinalBattle.Character/GearItems/FlamingSword.cs
@@ -1,0 +1,20 @@
+﻿namespace FinalBattle.Character.GearItems
+{
+    /// <inheritdoc />
+    /// <summary>
+    ///     A sword, deals 2 points of damage
+    /// </summary>
+    /// <seealso cref="T:FinalBattle.Character.GearItems.Gear" />
+    public class FlamingSword : Gear
+    {
+        #region Constructors
+        /// <inheritdoc />
+        public FlamingSword() : base("slash", 0.75f, 2, new AttackModifier("fire", AttackModifierType.Offensive, DamageType.Fire, 2)) {}
+        #endregion
+
+        #region Overrides of Attack
+        /// <inheritdoc />
+        public override int CalculateDamage() => Damage;
+        #endregion
+    }
+}

--- a/Part4/level52/FinalBattle.Character/GearItems/Gear.cs
+++ b/Part4/level52/FinalBattle.Character/GearItems/Gear.cs
@@ -12,37 +12,31 @@
 
         #region Constructors
         /// <inheritdoc />
-        protected Gear(string name, float chanceToHit, int damage, AttackModifier? attackModifier = null) : base(name, chanceToHit, damage) =>
-            Modifier = attackModifier;
+        protected Gear(string name, float chanceToHit, int damage, AttackModifier? attackModifier = null) : base(name, chanceToHit, damage, attackModifier) {}
 
         /// <inheritdoc />
-        protected Gear(string name, string description, float chanceToHit, int damage, AttackModifier? attackModifier = null) : base(description, chanceToHit, damage)
-        {
+        protected Gear(string name, string description, float chanceToHit, int damage, AttackModifier? attackModifier = null) : base(
+            description,
+            chanceToHit,
+            damage,
+            attackModifier) =>
             Description = name;
-            Modifier    = attackModifier;
-        }
         #endregion
 
         #region Properties
         /// <summary>
-        ///     Modifier applied to the attack's damage or chance to hit.
-        /// </summary>
-        public AttackModifier? Modifier {get;}
-        #endregion
-
-        #region Overrides of Object
-        /// <inheritdoc />
-        public override string ToString() => Name;
-
-        /// <summary>
         ///     The gear's description (weapon type)
         /// </summary>
-        /// <returns></returns>
         public string Description
         {
             get => string.IsNullOrWhiteSpace(_description) ? GetType().Name.ToUpper() : _description.ToUpper();
             private set => _description = value;
         }
+        #endregion
+
+        #region Overrides of Object
+        /// <inheritdoc />
+        public override string ToString() => Name;
         #endregion
     }
 }

--- a/Part4/level52/FinalBattle.Character/GearItems/Gear.cs
+++ b/Part4/level52/FinalBattle.Character/GearItems/Gear.cs
@@ -1,8 +1,5 @@
 ﻿namespace FinalBattle.Character.GearItems
 {
-    #region Using Directives
-    #endregion
-
     /// <inheritdoc />
     /// <summary>
     ///     Base class for items.
@@ -15,10 +12,22 @@
 
         #region Constructors
         /// <inheritdoc />
-        protected Gear(string name, float chanceToHit, int damage) : base(name, chanceToHit, damage) {}
+        protected Gear(string name, float chanceToHit, int damage, AttackModifier? attackModifier = null) : base(name, chanceToHit, damage) =>
+            Modifier = attackModifier;
 
         /// <inheritdoc />
-        protected Gear(string name, string description, float chanceToHit, int damage) : base(description, chanceToHit, damage) => Description = name;
+        protected Gear(string name, string description, float chanceToHit, int damage, AttackModifier? attackModifier = null) : base(description, chanceToHit, damage)
+        {
+            Description = name;
+            Modifier    = attackModifier;
+        }
+        #endregion
+
+        #region Properties
+        /// <summary>
+        ///     Modifier applied to the attack's damage or chance to hit.
+        /// </summary>
+        public AttackModifier? Modifier {get;}
         #endregion
 
         #region Overrides of Object

--- a/Part4/level52/FinalBattle.Character/Player/HumanPlayer.cs
+++ b/Part4/level52/FinalBattle.Character/Player/HumanPlayer.cs
@@ -6,6 +6,11 @@ namespace FinalBattle.Character.Player;
 using Humanizer;
 #endregion
 
+/// <inheritdoc />
+/// <summary>
+///     Represents a Human Player.
+/// </summary>
+/// <seealso cref="T:FinalBattle.Character.Player.Player" />
 public class HumanPlayer : Player
 {
     #region Constructors

--- a/Part4/level52/FinalBattle.Character/enum/AttackModifierType.cs
+++ b/Part4/level52/FinalBattle.Character/enum/AttackModifierType.cs
@@ -1,0 +1,19 @@
+﻿// FinalBattle.Character
+
+namespace FinalBattle.Character;
+
+/// <summary>
+///     Represents the type of attack modifier that can be applied to a character's attack.
+/// </summary>
+public enum AttackModifierType
+{
+    /// <summary>
+    ///     A defensive modifier that reduces damage taken or increases survivability.
+    /// </summary>
+    Defensive,
+
+    /// <summary>
+    ///     An offensive modifier that increases damage dealt or enhances attack capabilities.
+    /// </summary>
+    Offensive
+}

--- a/Part4/level52/FinalBattle.Character/enum/DamageType.cs
+++ b/Part4/level52/FinalBattle.Character/enum/DamageType.cs
@@ -20,5 +20,10 @@ public enum DamageType
     /// <summary>
     ///     Fire damage type.
     /// </summary>
-    Fire
+    Fire,
+
+    /// <summary>
+    ///     Physical damage type.
+    /// </summary>
+    Physical
 }

--- a/Part4/level52/FinalBattle.Character/enum/DamageType.cs
+++ b/Part4/level52/FinalBattle.Character/enum/DamageType.cs
@@ -15,5 +15,10 @@ public enum DamageType
     /// <summary>
     ///     Decoding damage type.
     /// </summary>
-    Decoding
+    Decoding,
+
+    /// <summary>
+    ///     Fire damage type.
+    /// </summary>
+    Fire
 }

--- a/Part4/level52/FinalBattle/Program.cs
+++ b/Part4/level52/FinalBattle/Program.cs
@@ -287,9 +287,9 @@ bool PerformAction(IEnumerable<Party?> parties, Action action, Player player, Ch
             if (result.WasSuccessful)
             {
                 // Apply offensive modifiers to the attack (applies to equipped gear only)
-                if (result.Attack is Gear && character?.EquippedGear?.Modifier != null)
+                if (result.Attack.AttackModifier != null)
                 {
-                    result = character.EquippedGear.Modifier.ModifyAttack(result);
+                    result = result.Attack is Gear ? character!.EquippedGear!.AttackModifier!.ModifyAttack(result) : result.Attack.AttackModifier.ModifyAttack(result);
                     Console.WriteLine(result.Description);
                 }
 

--- a/Part4/level52/FinalBattle/Program.cs
+++ b/Part4/level52/FinalBattle/Program.cs
@@ -286,7 +286,15 @@ bool PerformAction(IEnumerable<Party?> parties, Action action, Player player, Ch
         {
             if (result.WasSuccessful)
             {
-                if (target!.AttackModifier.HasModifier)
+                // Apply offensive modifiers to the attack (applies to equipped gear only)
+                if (result.Attack is Gear && character?.EquippedGear?.Modifier != null)
+                {
+                    result = character.EquippedGear.Modifier.ModifyAttack(result);
+                    Console.WriteLine(result.Description);
+                }
+
+                // Apply defensive modifiers to the target
+                if (target.AttackModifier.HasModifier)
                 {
                     result = target.AttackModifier.ModifyAttack(result);
                     Console.WriteLine(result.Description);


### PR DESCRIPTION
# Level 52, part 16 item 3: Add offensive attack modifiers

- Add offensive attack modifiers to attacks, both for equipped gear and standard attacks.
- Display attack modifiers in attack selection screen.